### PR TITLE
refactor(group): GroupResponse의 'userResponse'를 'hostUser'로 이름 변경

### DIFF
--- a/src/main/java/com/potato_y/where_are_you/group/dto/GroupResponse.java
+++ b/src/main/java/com/potato_y/where_are_you/group/dto/GroupResponse.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 public record GroupResponse(
     Long id,
     String groupName,
-    UserResponse userResponse,
+    UserResponse hostUser,
     LocalDateTime createAt,
     int memberNumber
 ) {

--- a/src/test/java/com/potato_y/where_are_you/group/GroupApiControllerTest.java
+++ b/src/test/java/com/potato_y/where_are_you/group/GroupApiControllerTest.java
@@ -97,8 +97,8 @@ class GroupApiControllerTest {
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.id").isNotEmpty())
         .andExpect(jsonPath("$.groupName").value(groupName))
-        .andExpect(jsonPath("$.userResponse.userId").value(testUser.getId()))
-        .andExpect(jsonPath("$.userResponse.nickname").value(testUser.getNickname()))
+        .andExpect(jsonPath("$.hostUser.userId").value(testUser.getId()))
+        .andExpect(jsonPath("$.hostUser.nickname").value(testUser.getNickname()))
         .andExpect(jsonPath("$.memberNumber").value(1));
   }
 
@@ -155,8 +155,8 @@ class GroupApiControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").isNotEmpty())
         .andExpect(jsonPath("$.groupName").value(groupName))
-        .andExpect(jsonPath("$.userResponse.userId").value(testUser.getId()))
-        .andExpect(jsonPath("$.userResponse.nickname").value(testUser.getNickname()))
+        .andExpect(jsonPath("$.hostUser.userId").value(testUser.getId()))
+        .andExpect(jsonPath("$.hostUser.nickname").value(testUser.getNickname()))
         .andExpect(jsonPath("$.memberNumber").value(1));
   }
 
@@ -230,8 +230,8 @@ class GroupApiControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").isNotEmpty())
         .andExpect(jsonPath("$.groupName").value(groupName))
-        .andExpect(jsonPath("$.userResponse.userId").value(testUser.getId()))
-        .andExpect(jsonPath("$.userResponse.nickname").value(testUser.getNickname()))
+        .andExpect(jsonPath("$.hostUser.userId").value(testUser.getId()))
+        .andExpect(jsonPath("$.hostUser.nickname").value(testUser.getNickname()))
         .andExpect(jsonPath("$.memberNumber").value(1));
   }
 
@@ -303,8 +303,8 @@ class GroupApiControllerTest {
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.id").isNotEmpty())
         .andExpect(jsonPath("$.groupName").value(groupName))
-        .andExpect(jsonPath("$.userResponse.userId").value(hostUser.getId()))
-        .andExpect(jsonPath("$.userResponse.nickname").value(hostUser.getNickname()))
+        .andExpect(jsonPath("$.hostUser.userId").value(hostUser.getId()))
+        .andExpect(jsonPath("$.hostUser.nickname").value(hostUser.getNickname()))
         .andExpect(jsonPath("$.memberNumber").value(2));
   }
 
@@ -421,13 +421,13 @@ class GroupApiControllerTest {
         .andExpect(jsonPath("$").isArray())
         .andExpect(jsonPath("$[0].id").value(hostGroup.getId()))
         .andExpect(jsonPath("$[0].groupName").value(hostGroup.getGroupName()))
-        .andExpect(jsonPath("$[0].userResponse.userId").value(testUser.getId()))
-        .andExpect(jsonPath("$[0].userResponse.nickname").value(testUser.getNickname()))
+        .andExpect(jsonPath("$[0].hostUser.userId").value(testUser.getId()))
+        .andExpect(jsonPath("$[0].hostUser.nickname").value(testUser.getNickname()))
         .andExpect(jsonPath("$[0].memberNumber").value(1))
         .andExpect(jsonPath("$[1].id").value(memberGroup.getId()))
         .andExpect(jsonPath("$[1].groupName").value(memberGroup.getGroupName()))
-        .andExpect(jsonPath("$[1].userResponse.userId").value(otherUser.getId()))
-        .andExpect(jsonPath("$[1].userResponse.nickname").value(otherUser.getNickname()))
+        .andExpect(jsonPath("$[1].hostUser.userId").value(otherUser.getId()))
+        .andExpect(jsonPath("$[1].hostUser.nickname").value(otherUser.getNickname()))
         .andExpect(jsonPath("$[1].memberNumber").value(2));
   }
 

--- a/src/test/java/com/potato_y/where_are_you/group/GroupServiceTest.java
+++ b/src/test/java/com/potato_y/where_are_you/group/GroupServiceTest.java
@@ -78,7 +78,7 @@ class GroupServiceTest {
 
     // then
     assertThat(response.groupName()).isEqualTo(groupName);
-    assertThat(response.userResponse().getNickname()).isEqualTo(testUser.getNickname());
+    assertThat(response.hostUser().getNickname()).isEqualTo(testUser.getNickname());
     assertThat(response.memberNumber()).isEqualTo(1);
   }
 
@@ -97,7 +97,7 @@ class GroupServiceTest {
 
     // then
     assertThat(response.groupName()).isEqualTo(group.getGroupName());
-    assertThat(response.userResponse().getNickname()).isEqualTo(testUser.getNickname());
+    assertThat(response.hostUser().getNickname()).isEqualTo(testUser.getNickname());
     assertThat(response.memberNumber()).isEqualTo(1);
   }
 
@@ -120,7 +120,7 @@ class GroupServiceTest {
 
     // then
     assertThat(response.groupName()).isEqualTo(group.getGroupName());
-    assertThat(response.userResponse().getNickname()).isEqualTo(testUser.getNickname());
+    assertThat(response.hostUser().getNickname()).isEqualTo(testUser.getNickname());
     assertThat(response.memberNumber()).isEqualTo(4);
   }
 
@@ -284,7 +284,7 @@ class GroupServiceTest {
 
     // then
     assertThat(response.groupName()).isEqualTo(groupName);
-    assertThat(response.userResponse().getNickname()).isEqualTo(testUser.getNickname());
+    assertThat(response.hostUser().getNickname()).isEqualTo(testUser.getNickname());
     assertThat(response.memberNumber()).isEqualTo(2);
   }
 
@@ -372,12 +372,12 @@ class GroupServiceTest {
 
     // 호스트 그룹 검증
     assertThat(responses.get(0).groupName()).isEqualTo(hostGroup.getGroupName());
-    assertThat(responses.get(0).userResponse().getNickname()).isEqualTo(user.getNickname());
+    assertThat(responses.get(0).hostUser().getNickname()).isEqualTo(user.getNickname());
     assertThat(responses.get(0).memberNumber()).isEqualTo(1); // 호스트만 있는 경우
 
     // 멤버 그룹 검증
     assertThat(responses.get(1).groupName()).isEqualTo(memberGroup.getGroupName());
-    assertThat(responses.get(1).userResponse().getNickname()).isEqualTo(otherUser.getNickname());
+    assertThat(responses.get(1).hostUser().getNickname()).isEqualTo(otherUser.getNickname());
     assertThat(responses.get(1).memberNumber()).isEqualTo(2); // 호스트 + 멤버 1명}
   }
 


### PR DESCRIPTION
이번 Pull request에는 다음의 내용이 포함되어 있습니다.

### Group
- 명확성과 직관성을 위해 GroupResponse의 'userResponse'를 'hostUser'로 이름 변경