### PR TITLE
develop ← Feature/group schedule management: 그룹 스케줄 목록 조회시 참석 여부를 함께 반환

### DIFF
--- a/src/main/java/com/potato_y/where_are_you/group/GroupApiController.java
+++ b/src/main/java/com/potato_y/where_are_you/group/GroupApiController.java
@@ -69,7 +69,7 @@ public class GroupApiController {
   }
 
   @DeleteMapping("/{groupId}")
-  public ResponseEntity deleteOrLeaveGroup(@PathVariable Long groupId) {
+  public ResponseEntity<Void> deleteOrLeaveGroup(@PathVariable Long groupId) {
     groupService.deleteOrLeaveGroup(groupId);
 
     return ResponseEntity.status(HttpStatus.OK).build();

--- a/src/main/java/com/potato_y/where_are_you/group/domain/Group.java
+++ b/src/main/java/com/potato_y/where_are_you/group/domain/Group.java
@@ -16,6 +16,8 @@ import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -32,6 +34,7 @@ public class Group {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "host_user_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private User hostUser;
 
   @NotNull

--- a/src/main/java/com/potato_y/where_are_you/group/domain/GroupMember.java
+++ b/src/main/java/com/potato_y/where_are_you/group/domain/GroupMember.java
@@ -4,6 +4,8 @@ import com.potato_y.where_are_you.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -42,14 +44,19 @@ public class GroupMember {
   @OnDelete(action = OnDeleteAction.CASCADE)
   private User user;
 
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  private GroupMemberType memberType;
+
   @CreatedDate
   @NotNull
   @Column(name = "created_at", updatable = false)
   private LocalDateTime createdAt;
 
   @Builder
-  public GroupMember(Group group, User user) {
+  public GroupMember(Group group, User user, GroupMemberType memberType) {
     this.group = group;
     this.user = user;
+    this.memberType = memberType;
   }
 }

--- a/src/main/java/com/potato_y/where_are_you/group/domain/GroupMemberType.java
+++ b/src/main/java/com/potato_y/where_are_you/group/domain/GroupMemberType.java
@@ -1,0 +1,5 @@
+package com.potato_y.where_are_you.group.domain;
+
+public enum GroupMemberType {
+  HOST, MEMBER
+}

--- a/src/main/java/com/potato_y/where_are_you/group/domain/GroupRepository.java
+++ b/src/main/java/com/potato_y/where_are_you/group/domain/GroupRepository.java
@@ -1,10 +1,7 @@
 package com.potato_y.where_are_you.group.domain;
 
-import com.potato_y.where_are_you.user.domain.User;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
 
-  List<Group> findByHostUser(User hostUser);
 }

--- a/src/main/java/com/potato_y/where_are_you/group/dto/GroupResponse.java
+++ b/src/main/java/com/potato_y/where_are_you/group/dto/GroupResponse.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 public record GroupResponse(
     Long id,
     String groupName,
-    UserResponse userResponse,
+    UserResponse hostUser,
     LocalDateTime createAt,
     int memberNumber
 ) {

--- a/src/main/java/com/potato_y/where_are_you/schedule/GroupScheduleApiController.java
+++ b/src/main/java/com/potato_y/where_are_you/schedule/GroupScheduleApiController.java
@@ -1,6 +1,7 @@
 package com.potato_y.where_are_you.schedule;
 
 import com.potato_y.where_are_you.schedule.dto.CreateGroupScheduleRequest;
+import com.potato_y.where_are_you.schedule.dto.GetGroupScheduleListResponse;
 import com.potato_y.where_are_you.schedule.dto.GroupScheduleResponse;
 import com.potato_y.where_are_you.user.dto.UserResponse;
 import java.util.List;
@@ -32,8 +33,9 @@ public class GroupScheduleApiController {
   }
 
   @GetMapping("")
-  public ResponseEntity<List<GroupScheduleResponse>> getGroupSchedules(@PathVariable Long groupId) {
-    List<GroupScheduleResponse> responses = groupScheduleService.getSchedules(groupId);
+  public ResponseEntity<List<GetGroupScheduleListResponse>> getGroupSchedules(
+      @PathVariable Long groupId) {
+    List<GetGroupScheduleListResponse> responses = groupScheduleService.getSchedules(groupId);
 
     return ResponseEntity.status(HttpStatus.OK).body(responses);
   }

--- a/src/main/java/com/potato_y/where_are_you/schedule/GroupScheduleService.java
+++ b/src/main/java/com/potato_y/where_are_you/schedule/GroupScheduleService.java
@@ -23,6 +23,7 @@ import com.potato_y.where_are_you.user.domain.User;
 import com.potato_y.where_are_you.user.dto.UserResponse;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -168,7 +169,10 @@ public class GroupScheduleService {
 
   @Transactional(readOnly = true)
   public boolean checkParticipation(User user, GroupSchedule schedule) {
-    return participationRepository.findByUserAndSchedule(user, schedule).isPresent();
+    Optional<Participation> participation = participationRepository
+        .findByUserAndSchedule(user, schedule);
+
+    return participation.isPresent() && participation.get().isParticipating();
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/potato_y/where_are_you/schedule/dto/GetGroupScheduleListResponse.java
+++ b/src/main/java/com/potato_y/where_are_you/schedule/dto/GetGroupScheduleListResponse.java
@@ -1,0 +1,16 @@
+package com.potato_y.where_are_you.schedule.dto;
+
+import com.potato_y.where_are_you.schedule.domain.GroupSchedule;
+
+public record GetGroupScheduleListResponse(
+    GroupScheduleResponse groupSchedule,
+    boolean isParticipating
+) {
+
+  public GetGroupScheduleListResponse(GroupSchedule groupSchedule, boolean isParticipating) {
+    this(
+        new GroupScheduleResponse(groupSchedule),
+        isParticipating
+    );
+  }
+}

--- a/src/test/java/com/potato_y/where_are_you/group/GroupApiControllerTest.java
+++ b/src/test/java/com/potato_y/where_are_you/group/GroupApiControllerTest.java
@@ -1,6 +1,7 @@
 package com.potato_y.where_are_you.group;
 
 import static com.potato_y.where_are_you.group.GroupTestUtils.createGroup;
+import static com.potato_y.where_are_you.group.GroupTestUtils.createGroupHost;
 import static com.potato_y.where_are_you.group.GroupTestUtils.createGroupMember;
 import static com.potato_y.where_are_you.user.UserTestUtils.createUser;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -97,8 +98,8 @@ class GroupApiControllerTest {
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.id").isNotEmpty())
         .andExpect(jsonPath("$.groupName").value(groupName))
-        .andExpect(jsonPath("$.userResponse.userId").value(testUser.getId()))
-        .andExpect(jsonPath("$.userResponse.nickname").value(testUser.getNickname()))
+        .andExpect(jsonPath("$.hostUser.userId").value(testUser.getId()))
+        .andExpect(jsonPath("$.hostUser.nickname").value(testUser.getNickname()))
         .andExpect(jsonPath("$.memberNumber").value(1));
   }
 
@@ -146,6 +147,7 @@ class GroupApiControllerTest {
     final String url = "/v1/groups/{groupId}";
     final String groupName = "test group";
     final Group group = groupRepository.save(createGroup(groupName, testUser));
+    groupMemberRepository.save(createGroupHost(group, testUser));
 
     // when
     ResultActions result = mockMvc.perform(get(url, group.getId()));
@@ -155,8 +157,8 @@ class GroupApiControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").isNotEmpty())
         .andExpect(jsonPath("$.groupName").value(groupName))
-        .andExpect(jsonPath("$.userResponse.userId").value(testUser.getId()))
-        .andExpect(jsonPath("$.userResponse.nickname").value(testUser.getNickname()))
+        .andExpect(jsonPath("$.hostUser.userId").value(testUser.getId()))
+        .andExpect(jsonPath("$.hostUser.nickname").value(testUser.getNickname()))
         .andExpect(jsonPath("$.memberNumber").value(1));
   }
 
@@ -215,6 +217,7 @@ class GroupApiControllerTest {
 
     Group group = groupRepository.save(
         Group.builder().groupName("group").hostUser(testUser).build());
+    groupMemberRepository.save(createGroupHost(group, testUser));
 
     CreateGroupRequest request = new CreateGroupRequest(groupName);
     final String requestBody = objectMapper.writeValueAsString(request);
@@ -230,8 +233,8 @@ class GroupApiControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").isNotEmpty())
         .andExpect(jsonPath("$.groupName").value(groupName))
-        .andExpect(jsonPath("$.userResponse.userId").value(testUser.getId()))
-        .andExpect(jsonPath("$.userResponse.nickname").value(testUser.getNickname()))
+        .andExpect(jsonPath("$.hostUser.userId").value(testUser.getId()))
+        .andExpect(jsonPath("$.hostUser.nickname").value(testUser.getNickname()))
         .andExpect(jsonPath("$.memberNumber").value(1));
   }
 
@@ -292,6 +295,7 @@ class GroupApiControllerTest {
 
     Group group = groupRepository.save(
         Group.builder().groupName(groupName).hostUser(hostUser).build());
+    groupMemberRepository.save(createGroupHost(group, hostUser));
     groupInviteCodeRepository.save(
         GroupInviteCode.builder().group(group).code(code).createUser(hostUser).build());
 
@@ -303,8 +307,8 @@ class GroupApiControllerTest {
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.id").isNotEmpty())
         .andExpect(jsonPath("$.groupName").value(groupName))
-        .andExpect(jsonPath("$.userResponse.userId").value(hostUser.getId()))
-        .andExpect(jsonPath("$.userResponse.nickname").value(hostUser.getNickname()))
+        .andExpect(jsonPath("$.hostUser.userId").value(hostUser.getId()))
+        .andExpect(jsonPath("$.hostUser.nickname").value(hostUser.getNickname()))
         .andExpect(jsonPath("$.memberNumber").value(2));
   }
 
@@ -406,10 +410,12 @@ class GroupApiControllerTest {
     final String url = "/v1/groups";
 
     Group hostGroup = groupRepository.save(createGroup("host group", testUser));
+    groupMemberRepository.save(createGroupHost(hostGroup, testUser));
 
     // 멤버로 있는 그룹 생성
     User otherUser = userRepository.save(createUser("other@mail.com", "other user", "2"));
     Group memberGroup = groupRepository.save(createGroup("member group", otherUser));
+    groupMemberRepository.save(createGroupHost(memberGroup, otherUser));
     groupMemberRepository.save(createGroupMember(memberGroup, testUser));
 
     // when
@@ -421,13 +427,13 @@ class GroupApiControllerTest {
         .andExpect(jsonPath("$").isArray())
         .andExpect(jsonPath("$[0].id").value(hostGroup.getId()))
         .andExpect(jsonPath("$[0].groupName").value(hostGroup.getGroupName()))
-        .andExpect(jsonPath("$[0].userResponse.userId").value(testUser.getId()))
-        .andExpect(jsonPath("$[0].userResponse.nickname").value(testUser.getNickname()))
+        .andExpect(jsonPath("$[0].hostUser.userId").value(testUser.getId()))
+        .andExpect(jsonPath("$[0].hostUser.nickname").value(testUser.getNickname()))
         .andExpect(jsonPath("$[0].memberNumber").value(1))
         .andExpect(jsonPath("$[1].id").value(memberGroup.getId()))
         .andExpect(jsonPath("$[1].groupName").value(memberGroup.getGroupName()))
-        .andExpect(jsonPath("$[1].userResponse.userId").value(otherUser.getId()))
-        .andExpect(jsonPath("$[1].userResponse.nickname").value(otherUser.getNickname()))
+        .andExpect(jsonPath("$[1].hostUser.userId").value(otherUser.getId()))
+        .andExpect(jsonPath("$[1].hostUser.nickname").value(otherUser.getNickname()))
         .andExpect(jsonPath("$[1].memberNumber").value(2));
   }
 

--- a/src/test/java/com/potato_y/where_are_you/group/GroupTestUtils.java
+++ b/src/test/java/com/potato_y/where_are_you/group/GroupTestUtils.java
@@ -3,6 +3,7 @@ package com.potato_y.where_are_you.group;
 import com.potato_y.where_are_you.group.domain.Group;
 import com.potato_y.where_are_you.group.domain.GroupInviteCode;
 import com.potato_y.where_are_you.group.domain.GroupMember;
+import com.potato_y.where_are_you.group.domain.GroupMemberType;
 import com.potato_y.where_are_you.user.domain.User;
 
 public class GroupTestUtils {
@@ -14,10 +15,19 @@ public class GroupTestUtils {
         .build();
   }
 
+  public static GroupMember createGroupHost(Group group, User user) {
+    return GroupMember.builder()
+        .group(group)
+        .user(user)
+        .memberType(GroupMemberType.HOST)
+        .build();
+  }
+
   public static GroupMember createGroupMember(Group group, User user) {
     return GroupMember.builder()
         .group(group)
         .user(user)
+        .memberType(GroupMemberType.MEMBER)
         .build();
   }
 

--- a/src/test/java/com/potato_y/where_are_you/location/LocationShareApiControllerTest.java
+++ b/src/test/java/com/potato_y/where_are_you/location/LocationShareApiControllerTest.java
@@ -1,0 +1,285 @@
+package com.potato_y.where_are_you.location;
+
+import static com.potato_y.where_are_you.group.GroupTestUtils.createGroup;
+import static com.potato_y.where_are_you.group.GroupTestUtils.createGroupHost;
+import static com.potato_y.where_are_you.group.GroupTestUtils.createGroupMember;
+import static com.potato_y.where_are_you.schedule.GroupScheduleUtils.createParticipation;
+import static com.potato_y.where_are_you.schedule.GroupScheduleUtils.createScheduleCase1;
+import static com.potato_y.where_are_you.schedule.GroupScheduleUtils.createScheduleCase2;
+import static com.potato_y.where_are_you.user.UserTestUtils.createUser;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.potato_y.where_are_you.group.domain.Group;
+import com.potato_y.where_are_you.group.domain.GroupMemberRepository;
+import com.potato_y.where_are_you.group.domain.GroupRepository;
+import com.potato_y.where_are_you.location.domain.UserLocation;
+import com.potato_y.where_are_you.location.domain.UserLocationRepository;
+import com.potato_y.where_are_you.location.dto.UpdateUserLocationRequest;
+import com.potato_y.where_are_you.schedule.domain.GroupSchedule;
+import com.potato_y.where_are_you.schedule.domain.GroupScheduleRepository;
+import com.potato_y.where_are_you.schedule.domain.ParticipationRepository;
+import com.potato_y.where_are_you.user.domain.User;
+import com.potato_y.where_are_you.user.domain.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@ActiveProfiles("test")
+class LocationShareApiControllerTest {
+
+  @Autowired
+  protected MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private WebApplicationContext context;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private GroupRepository groupRepository;
+
+  @Autowired
+  private GroupMemberRepository groupMemberRepository;
+
+  @Autowired
+  private GroupScheduleRepository scheduleRepository;
+
+  @Autowired
+  private ParticipationRepository participationRepository;
+
+  @Autowired
+  private UserLocationRepository userLocationRepository;
+
+  private User testUser;
+
+  @BeforeEach
+  void setUp() {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+
+    userLocationRepository.deleteAll();
+    participationRepository.deleteAll();
+    scheduleRepository.deleteAll();
+    groupMemberRepository.deleteAll();
+    groupRepository.deleteAll();
+    userRepository.deleteAll();
+
+    testUser = userRepository.save(createUser("test@mail.com", "test user", "1"));
+  }
+
+  @Test
+  @WithMockUser("1")
+  @DisplayName("updateUserLocation(): 사용자 위치를 업데이트 할 수 있다.")
+  void successUpdateUserLocation() throws Exception {
+    // given
+    final String url = "/v1/locations/{scheduleId}";
+
+    Group group = groupRepository.save(createGroup("test group", testUser));
+    groupMemberRepository.save(createGroupHost(group, testUser));
+    GroupSchedule schedule = scheduleRepository.save(createScheduleCase1(group, testUser));
+    participationRepository.save(createParticipation(schedule, testUser, true));
+
+    UpdateUserLocationRequest request = new UpdateUserLocationRequest(1, 3);
+    final String requestBody = objectMapper.writeValueAsString(request);
+
+    // when
+    ResultActions result = mockMvc.perform(
+        put(url, schedule.getId()).contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(requestBody));
+
+    // then
+    result.andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser("1")
+  @DisplayName("updateUserLocation(): 참여자가 아니라면 업데이트 할 수 없다 1")
+  void failUpdateUserLocation_notParticipation() throws Exception {
+    // given
+    final String url = "/v1/locations/{scheduleId}";
+
+    Group group = groupRepository.save(createGroup("test group", testUser));
+    groupMemberRepository.save(createGroupHost(group, testUser));
+    GroupSchedule schedule = scheduleRepository.save(createScheduleCase1(group, testUser));
+    participationRepository.save(createParticipation(schedule, testUser, false));
+
+    UpdateUserLocationRequest request = new UpdateUserLocationRequest(1, 3);
+    final String requestBody = objectMapper.writeValueAsString(request);
+
+    // when
+    ResultActions result = mockMvc.perform(
+        put(url, schedule.getId()).contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(requestBody));
+
+    // then
+    result.andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser("1")
+  @DisplayName("updateUserLocation(): 참여자가 아니라면 업데이트 할 수 없다 2")
+  void failUpdateUserLocation_notParticipationEntity() throws Exception {
+    // given
+    final String url = "/v1/locations/{scheduleId}";
+
+    Group group = groupRepository.save(createGroup("test group", testUser));
+    groupMemberRepository.save(createGroupHost(group, testUser));
+    GroupSchedule schedule = scheduleRepository.save(createScheduleCase1(group, testUser));
+
+    UpdateUserLocationRequest request = new UpdateUserLocationRequest(1, 3);
+    final String requestBody = objectMapper.writeValueAsString(request);
+
+    // when
+    ResultActions result = mockMvc.perform(
+        put(url, schedule.getId()).contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(requestBody));
+
+    // then
+    result.andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser("1")
+  @DisplayName("updateUserLocation(): 공유 허용 시간이 아니면 공유할 수 없다")
+  void failUpdateUserLocation_notShareTime() throws Exception {
+    // given
+    final String url = "/v1/locations/{scheduleId}";
+
+    Group group = groupRepository.save(createGroup("test group", testUser));
+    groupMemberRepository.save(createGroupHost(group, testUser));
+    GroupSchedule schedule = scheduleRepository.save(createScheduleCase2(group, testUser));
+    participationRepository.save(createParticipation(schedule, testUser, true));
+
+    UpdateUserLocationRequest request = new UpdateUserLocationRequest(1, 3);
+    final String requestBody = objectMapper.writeValueAsString(request);
+
+    // when
+    ResultActions result = mockMvc.perform(
+        put(url, schedule.getId()).contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(requestBody));
+
+    // then
+    result.andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser("1")
+  @DisplayName("getScheduleMemberLocations(): 그룹원의 위치를 가져올 수 있다.")
+  void successGetScheduleMemberLocations() throws Exception {
+    // given
+    final String url = "/v1/locations/{scheduleId}";
+
+    User memberUser = userRepository.save(createUser("member@mail.com", "member", "123"));
+
+    Group group = groupRepository.save(createGroup("test group", testUser));
+    groupMemberRepository.save(createGroupHost(group, testUser));
+    groupMemberRepository.save(createGroupMember(group, memberUser));
+    GroupSchedule schedule = scheduleRepository.save(createScheduleCase1(group, testUser));
+    participationRepository.save(createParticipation(schedule, testUser, true));
+    participationRepository.save(createParticipation(schedule, memberUser, true));
+
+    var testUserLocation = userLocationRepository.save(
+        UserLocation.builder()
+            .user(testUser)
+            .locationLatitude(123.567)
+            .locationLongitude(456.123)
+            .build());
+
+    var memberUserLocation = userLocationRepository.save(
+        UserLocation.builder()
+            .user(memberUser)
+            .locationLatitude(1123.34)
+            .locationLongitude(342.12)
+            .build());
+
+    // when
+    ResultActions result = mockMvc.perform(get(url, schedule.getId()));
+
+    // then
+    result
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$[0].user.userId").value(testUser.getId()))
+        .andExpect(jsonPath("$[0].user.nickname").value(testUser.getNickname()))
+        .andExpect(jsonPath("$[0].user.email").value(testUser.getEmail()))
+        .andExpect(jsonPath("$[0].location.locationLatitude").value(
+            testUserLocation.getLocationLatitude()))
+        .andExpect(jsonPath("$[0].location.locationLongitude").value(
+            testUserLocation.getLocationLongitude()))
+
+        .andExpect(jsonPath("$[1].user.userId").value(memberUser.getId()))
+        .andExpect(jsonPath("$[1].user.nickname").value(memberUser.getNickname()))
+        .andExpect(jsonPath("$[1].user.email").value(memberUser.getEmail()))
+        .andExpect(jsonPath("$[1].location.locationLatitude").value(
+            memberUserLocation.getLocationLatitude()))
+        .andExpect(jsonPath("$[1].location.locationLongitude").value(
+            memberUserLocation.getLocationLongitude()));
+  }
+
+  @Test
+  @WithMockUser("1")
+  @DisplayName("getScheduleMemberLocations(): 참여자가 아니라면 조회할 수 없다.")
+  void successGetScheduleMemberLocations_notParticipation() throws Exception {
+    // given
+    final String url = "/v1/locations/{scheduleId}";
+
+    User memberUser = userRepository.save(createUser("member@mail.com", "member", "123"));
+
+    Group group = groupRepository.save(createGroup("test group", testUser));
+    groupMemberRepository.save(createGroupHost(group, testUser));
+    groupMemberRepository.save(createGroupMember(group, memberUser));
+    GroupSchedule schedule = scheduleRepository.save(createScheduleCase1(group, testUser));
+    participationRepository.save(createParticipation(schedule, memberUser, true));
+
+    // when
+    ResultActions result = mockMvc.perform(get(url, schedule.getId()));
+
+    // then
+    result.andExpect(status().isBadRequest());
+  }
+
+
+  @Test
+  @WithMockUser("1")
+  @DisplayName("getScheduleMemberLocations(): 공유 시간이 아니라면 조회할 수 없다.")
+  void successGetScheduleMemberLocations_notShareTime() throws Exception {
+    // given
+    final String url = "/v1/locations/{scheduleId}";
+
+    User memberUser = userRepository.save(createUser("member@mail.com", "member", "123"));
+
+    Group group = groupRepository.save(createGroup("test group", testUser));
+    groupMemberRepository.save(createGroupHost(group, testUser));
+    groupMemberRepository.save(createGroupMember(group, memberUser));
+    GroupSchedule schedule = scheduleRepository.save(createScheduleCase2(group, testUser));
+    participationRepository.save(createParticipation(schedule, memberUser, true));
+
+    // when
+    ResultActions result = mockMvc.perform(get(url, schedule.getId()));
+
+    // then
+    result.andExpect(status().isBadRequest());
+  }
+}

--- a/src/test/java/com/potato_y/where_are_you/location/LocationShareServiceTest.java
+++ b/src/test/java/com/potato_y/where_are_you/location/LocationShareServiceTest.java
@@ -1,0 +1,205 @@
+package com.potato_y.where_are_you.location;
+
+import static com.potato_y.where_are_you.group.GroupTestUtils.createGroup;
+import static com.potato_y.where_are_you.user.UserTestUtils.createUser;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.potato_y.where_are_you.authentication.CurrentUserProvider;
+import com.potato_y.where_are_you.error.exception.BadRequestException;
+import com.potato_y.where_are_you.group.domain.Group;
+import com.potato_y.where_are_you.location.domain.UserLocation;
+import com.potato_y.where_are_you.location.domain.UserLocationRepository;
+import com.potato_y.where_are_you.location.dto.UpdateUserLocationRequest;
+import com.potato_y.where_are_you.schedule.GroupScheduleService;
+import com.potato_y.where_are_you.schedule.domain.GroupSchedule;
+import com.potato_y.where_are_you.user.domain.User;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LocationShareServiceTest {
+
+  @InjectMocks
+  private LocationShareService locationShareService;
+
+  @Mock
+  private GroupScheduleService groupScheduleService;
+
+  @Mock
+  private UserLocationRepository userLocationRepository;
+
+  @Mock
+  private CurrentUserProvider currentUserProvider;
+
+  private User testUser;
+
+  private Group testGroup;
+
+  @BeforeEach
+  void setUp() {
+    testUser = createUser("test@mail.com", "test user", "1");
+    testGroup = createGroup("group", testUser);
+    given(currentUserProvider.getCurrentUser()).willReturn(testUser);
+  }
+
+  @Test
+  @DisplayName("updateUserLocation(): 사용자의 위치를 저장하고 업데이트 한다.")
+  void successUpdateUserLocation_newLocation() {
+    final var scheduleId = 1L;
+    GroupSchedule schedule = GroupSchedule.builder()
+        .title("스케줄")
+        .startTime(LocalDateTime.now().plusMinutes(25))
+        .endTime(LocalDateTime.now().plusHours(1))
+        .user(testUser)
+        .group(testGroup)
+        .isAlarmEnabled(true)
+        .alarmBeforeHours(1)
+        .build();
+
+    UpdateUserLocationRequest request = new UpdateUserLocationRequest(123.2, 456.1);
+
+    given(groupScheduleService.getSchedule(scheduleId)).willReturn(schedule);
+    given(groupScheduleService.checkParticipation(testUser, schedule)).willReturn(true);
+    given(userLocationRepository.findByUser(testUser)).willReturn(Optional.empty());
+    given(userLocationRepository.save(any(UserLocation.class))).willAnswer(
+        invocation -> invocation.getArgument(0));
+
+    locationShareService.updateUserLocation(scheduleId, request);
+
+    then(userLocationRepository).should(times(1)).save(any(UserLocation.class));
+  }
+
+  @Test
+  @DisplayName("updateUserLocation(): 사용자의 위치를 업데이트 한다.")
+  void successUpdateUserLocation_updateLocation() {
+    final var scheduleId = 1L;
+    GroupSchedule schedule = GroupSchedule.builder()
+        .title("스케줄")
+        .startTime(LocalDateTime.now().plusMinutes(25))
+        .endTime(LocalDateTime.now().plusHours(1))
+        .user(testUser)
+        .group(testGroup)
+        .isAlarmEnabled(true)
+        .alarmBeforeHours(1)
+        .build();
+    final UserLocation location = UserLocation.builder()
+        .user(testUser)
+        .locationLatitude(1)
+        .locationLongitude(2)
+        .build();
+
+    UpdateUserLocationRequest request = new UpdateUserLocationRequest(123.2, 456.1);
+
+    given(groupScheduleService.getSchedule(scheduleId)).willReturn(schedule);
+    given(groupScheduleService.checkParticipation(testUser, schedule)).willReturn(true);
+    given(userLocationRepository.findByUser(testUser)).willReturn(Optional.of(location));
+
+    locationShareService.updateUserLocation(scheduleId, request);
+
+    then(userLocationRepository).should(never()).save(any(UserLocation.class));
+  }
+
+  @Test
+  @DisplayName("updateUserLocation(): 공유 시간이 아니라면 예외가 발생한다.")
+  void failUpdateUserLocation_notShareTime() {
+    final var scheduleId = 1L;
+    GroupSchedule schedule = GroupSchedule.builder()
+        .title("스케줄")
+        .startTime(LocalDateTime.now().plusDays(25))
+        .endTime(LocalDateTime.now().plusDays(26))
+        .user(testUser)
+        .group(testGroup)
+        .isAlarmEnabled(true)
+        .alarmBeforeHours(1)
+        .build();
+
+    UpdateUserLocationRequest request = new UpdateUserLocationRequest(123.2, 456.1);
+
+    given(groupScheduleService.getSchedule(scheduleId)).willReturn(schedule);
+    given(groupScheduleService.checkParticipation(testUser, schedule)).willReturn(true);
+
+    assertThatThrownBy(
+        () -> locationShareService.updateUserLocation(scheduleId, request))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  @DisplayName("updateUserLocation(): 참여자가 아니라면 예외가 발생한다.")
+  void failUpdateUserLocation_notParticipation() {
+    final var scheduleId = 1L;
+    GroupSchedule schedule = GroupSchedule.builder()
+        .title("스케줄")
+        .startTime(LocalDateTime.now().plusMinutes(25))
+        .endTime(LocalDateTime.now().plusHours(1))
+        .user(testUser)
+        .group(testGroup)
+        .isAlarmEnabled(true)
+        .alarmBeforeHours(1)
+        .build();
+
+    UpdateUserLocationRequest request = new UpdateUserLocationRequest(123.2, 456.1);
+
+    given(groupScheduleService.getSchedule(scheduleId)).willReturn(schedule);
+    given(groupScheduleService.checkParticipation(testUser, schedule)).willReturn(false);
+
+    assertThatThrownBy(
+        () -> locationShareService.updateUserLocation(scheduleId, request))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  @DisplayName("getScheduleMemberLocations(): 공유 시간이 아니라면 예외가 발생한다.")
+  void failGetScheduleMemberLocations_notShareTime() {
+    final var scheduleId = 1L;
+    GroupSchedule schedule = GroupSchedule.builder()
+        .title("스케줄")
+        .startTime(LocalDateTime.now().plusDays(25))
+        .endTime(LocalDateTime.now().plusDays(26))
+        .user(testUser)
+        .group(testGroup)
+        .isAlarmEnabled(true)
+        .alarmBeforeHours(1)
+        .build();
+
+    given(groupScheduleService.getSchedule(scheduleId)).willReturn(schedule);
+    given(groupScheduleService.checkParticipation(testUser, schedule)).willReturn(true);
+
+    assertThatThrownBy(
+        () -> locationShareService.getScheduleMemberLocations(scheduleId))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  @DisplayName("getScheduleMemberLocations(): 참여자가 아니라면 예외가 발생한다.")
+  void failGetScheduleMemberLocations() {
+    final var scheduleId = 1L;
+    GroupSchedule schedule = GroupSchedule.builder()
+        .title("스케줄")
+        .startTime(LocalDateTime.now().plusMinutes(25))
+        .endTime(LocalDateTime.now().plusHours(1))
+        .user(testUser)
+        .group(testGroup)
+        .isAlarmEnabled(true)
+        .alarmBeforeHours(1)
+        .build();
+
+    given(groupScheduleService.getSchedule(scheduleId)).willReturn(schedule);
+    given(groupScheduleService.checkParticipation(testUser, schedule)).willReturn(false);
+
+    assertThatThrownBy(
+        () -> locationShareService.getScheduleMemberLocations(scheduleId))
+        .isInstanceOf(BadRequestException.class);
+  }
+}

--- a/src/test/java/com/potato_y/where_are_you/schedule/GroupScheduleUtils.java
+++ b/src/test/java/com/potato_y/where_are_you/schedule/GroupScheduleUtils.java
@@ -1,0 +1,56 @@
+package com.potato_y.where_are_you.schedule;
+
+import com.potato_y.where_are_you.group.domain.Group;
+import com.potato_y.where_are_you.schedule.domain.GroupSchedule;
+import com.potato_y.where_are_you.schedule.domain.Participation;
+import com.potato_y.where_are_you.user.domain.User;
+import java.time.LocalDateTime;
+
+public class GroupScheduleUtils {
+
+  /**
+   * 일반적인 정상 케이스 1 <br> 일정 시작 시각: 25분 뒤 <br> 일정 종료 시각: 1시간 뒤 <br> 알람 활성화: true <br> 알람 시간: 1시간 <br>
+   */
+  public static GroupSchedule createScheduleCase1(Group group, User user) {
+    return GroupSchedule.builder()
+        .group(group)
+        .user(user)
+        .title("test group")
+        .startTime(LocalDateTime.now().plusMinutes(25))
+        .endTime(LocalDateTime.now().plusHours(1))
+        .isAlarmEnabled(true)
+        .alarmBeforeHours(1)
+        .location("테스트 장소")
+        .locationLatitude(123.456)
+        .locationLongitude(234.567)
+        .build();
+  }
+
+  /**
+   * 공유 시간이 많이 남은 케이스 <br> 일정 시작 시각: 25일 뒤 <br> 일정 종료 시각: 26일 뒤 <br> 알람 활성화: true <br> 알람 시간: 1시간
+   * <br>
+   */
+  public static GroupSchedule createScheduleCase2(Group group, User user) {
+    return GroupSchedule.builder()
+        .group(group)
+        .user(user)
+        .title("test group")
+        .startTime(LocalDateTime.now().plusDays(25))
+        .endTime(LocalDateTime.now().plusDays(26))
+        .isAlarmEnabled(true)
+        .alarmBeforeHours(1)
+        .location("테스트 장소")
+        .locationLatitude(123.456)
+        .locationLongitude(234.567)
+        .build();
+  }
+
+  public static Participation createParticipation(GroupSchedule schedule, User user,
+      boolean isParticipating) {
+    return Participation.builder()
+        .schedule(schedule)
+        .user(user)
+        .isParticipating(isParticipating)
+        .build();
+  }
+}


### PR DESCRIPTION
**이번 Pull request에는 다음의 내용이 포함되어 있습니다.**

### Group Schedule

- 스케줄 목록을 조회할 때 참여 여부를 함께 반환하도록 추가합니다.
- 참여하지 않아도 레코드 값이 있으면 참여로 처리되는 문제가 수정 되었습니다.
- LocationShare와 관련된 클래스의 테스트 코드가 추가되었습니다.