### PR TITLE
develop ← feature/improve test performance

### DIFF
--- a/src/main/java/com/potato_y/where_are_you/firebase/domain/FcmToken.java
+++ b/src/main/java/com/potato_y/where_are_you/firebase/domain/FcmToken.java
@@ -16,6 +16,8 @@ import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -32,6 +34,7 @@ public class FcmToken {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", unique = true, nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private User user;
 
   @NotNull

--- a/src/test/java/com/potato_y/where_are_you/config/jwt/TokenProviderTest.java
+++ b/src/test/java/com/potato_y/where_are_you/config/jwt/TokenProviderTest.java
@@ -18,11 +18,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")
 public class TokenProviderTest {
 

--- a/src/test/java/com/potato_y/where_are_you/firebase/FirebaseApiControllerTest.java
+++ b/src/test/java/com/potato_y/where_are_you/firebase/FirebaseApiControllerTest.java
@@ -1,6 +1,7 @@
 package com.potato_y.where_are_you.firebase;
 
 import static com.potato_y.where_are_you.user.UserTestUtils.createUser;
+import static com.potato_y.where_are_you.utils.SecurityContextUtils.setAuthentication;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -19,8 +20,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -29,7 +28,6 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")
 class FirebaseApiControllerTest {
 
@@ -58,10 +56,10 @@ class FirebaseApiControllerTest {
     userRepository.deleteAll();
 
     testUser = userRepository.save(createUser("test@mail.com", "test user", "1"));
+    setAuthentication(testUser);
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("saveOrUpdateFcmToken(): Token을 업데이트 할 수 있다.")
   void successSaveOrUpdateFcmToken_update() throws Exception {
     // given
@@ -87,7 +85,6 @@ class FirebaseApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("saveOrUpdateFcmToken(): Token을 저장할 수 있다.")
   void successSaveOrUpdateFcmToken_save() throws Exception {
     // given
@@ -108,7 +105,6 @@ class FirebaseApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("saveOrUpdateFcmToken(): 공백 Token은 업데이트 할 수 없다.")
   void failSaveOrUpdateFcmToken_update() throws Exception {
     // given
@@ -132,7 +128,6 @@ class FirebaseApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("saveOrUpdateFcmToken(): 빈 Token은 저장할 수 없다.")
   void failSaveOrUpdateFcmToken_save() throws Exception {
     // given

--- a/src/test/java/com/potato_y/where_are_you/location/LocationShareApiControllerTest.java
+++ b/src/test/java/com/potato_y/where_are_you/location/LocationShareApiControllerTest.java
@@ -7,6 +7,7 @@ import static com.potato_y.where_are_you.schedule.GroupScheduleUtils.createParti
 import static com.potato_y.where_are_you.schedule.GroupScheduleUtils.createScheduleCase1;
 import static com.potato_y.where_are_you.schedule.GroupScheduleUtils.createScheduleCase2;
 import static com.potato_y.where_are_you.user.UserTestUtils.createUser;
+import static com.potato_y.where_are_you.utils.SecurityContextUtils.setAuthentication;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -34,8 +35,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -44,7 +43,6 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")
 class LocationShareApiControllerTest {
 
@@ -92,10 +90,10 @@ class LocationShareApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("updateUserLocation(): 사용자 위치를 업데이트 할 수 있다.")
   void successUpdateUserLocation_noData() throws Exception {
     // given
+    setAuthentication(testUser);
     final String url = "/v1/locations/{scheduleId}";
 
     Group group = groupRepository.save(createGroup("test group", testUser));
@@ -122,10 +120,10 @@ class LocationShareApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("updateUserLocation(): 사용자 위치를 업데이트 할 수 있다.")
   void successUpdateUserLocation_updateData() throws Exception {
     // given
+    setAuthentication(testUser);
     final String url = "/v1/locations/{scheduleId}";
 
     Group group = groupRepository.save(createGroup("test group", testUser));
@@ -154,10 +152,10 @@ class LocationShareApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("updateUserLocation(): 참여자가 아니라면 업데이트 할 수 없다 1")
   void failUpdateUserLocation_notParticipation() throws Exception {
     // given
+    setAuthentication(testUser);
     final String url = "/v1/locations/{scheduleId}";
 
     Group group = groupRepository.save(createGroup("test group", testUser));
@@ -178,10 +176,10 @@ class LocationShareApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("updateUserLocation(): 참여자가 아니라면 업데이트 할 수 없다 2")
   void failUpdateUserLocation_notParticipationEntity() throws Exception {
     // given
+    setAuthentication(testUser);
     final String url = "/v1/locations/{scheduleId}";
 
     Group group = groupRepository.save(createGroup("test group", testUser));
@@ -201,10 +199,10 @@ class LocationShareApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("updateUserLocation(): 공유 허용 시간이 아니면 공유할 수 없다")
   void failUpdateUserLocation_notShareTime() throws Exception {
     // given
+    setAuthentication(testUser);
     final String url = "/v1/locations/{scheduleId}";
 
     Group group = groupRepository.save(createGroup("test group", testUser));
@@ -225,10 +223,10 @@ class LocationShareApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("getScheduleMemberLocations(): 그룹원의 위치를 가져올 수 있다.")
   void successGetScheduleMemberLocations() throws Exception {
     // given
+    setAuthentication(testUser);
     final String url = "/v1/locations/{scheduleId}";
 
     User memberUser = userRepository.save(createUser("member@mail.com", "member", "123"));
@@ -288,10 +286,10 @@ class LocationShareApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("getScheduleMemberLocations(): 참여자가 아니라면 조회할 수 없다.")
   void successGetScheduleMemberLocations_notParticipation() throws Exception {
     // given
+    setAuthentication(testUser);
     final String url = "/v1/locations/{scheduleId}";
 
     User memberUser = userRepository.save(createUser("member@mail.com", "member", "123"));
@@ -311,10 +309,10 @@ class LocationShareApiControllerTest {
 
 
   @Test
-  @WithMockUser("1")
   @DisplayName("getScheduleMemberLocations(): 공유 시간이 아니라면 조회할 수 없다.")
   void successGetScheduleMemberLocations_notShareTime() throws Exception {
     // given
+    setAuthentication(testUser);
     final String url = "/v1/locations/{scheduleId}";
 
     User memberUser = userRepository.save(createUser("member@mail.com", "member", "123"));
@@ -333,10 +331,10 @@ class LocationShareApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("updateStateMessage(): 사용자 빈 위치를 저장하고, 상태 메시지를 업데이트 할 수 있다")
   void successUpdateStateMessage_noData() throws Exception {
     // given
+    setAuthentication(testUser);
     final String url = "/v1/locations/{scheduleId}/state-message";
 
     Group group = groupRepository.save(createGroup("test group", testUser));
@@ -363,10 +361,10 @@ class LocationShareApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("updateStateMessage(): 기존의 사용자 위치로부터 상태 메시지를 업데이트 할 수 있다")
   void successUpdateStateMessage_updateData() throws Exception {
     // given
+    setAuthentication(testUser);
     final String url = "/v1/locations/{scheduleId}/state-message";
 
     Group group = groupRepository.save(createGroup("test group", testUser));
@@ -395,10 +393,10 @@ class LocationShareApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("updateStateMessage(): 참여자가 아니라면 업데이트 할 수 없다 1")
   void failUpdateStateMessage_notParticipation() throws Exception {
     // given
+    setAuthentication(testUser);
     final String url = "/v1/locations/{scheduleId}/state-message";
 
     Group group = groupRepository.save(createGroup("test group", testUser));
@@ -419,10 +417,10 @@ class LocationShareApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("updateStateMessage(): 참여자가 아니라면 업데이트 할 수 없다 2")
   void failUpdateStateMessage_notParticipationEntity() throws Exception {
     // given
+    setAuthentication(testUser);
     final String url = "/v1/locations/{scheduleId}/state-message";
 
     Group group = groupRepository.save(createGroup("test group", testUser));
@@ -442,10 +440,10 @@ class LocationShareApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("updateStateMessage(): 공유 허용 시간이 아니면 공유할 수 없다")
   void failUpdateStateMessage_notShareTime() throws Exception {
     // given
+    setAuthentication(testUser);
     final String url = "/v1/locations/{scheduleId}/state-message";
 
     Group group = groupRepository.save(createGroup("test group", testUser));

--- a/src/test/java/com/potato_y/where_are_you/schedule/GroupScheduleApiControllerTest.java
+++ b/src/test/java/com/potato_y/where_are_you/schedule/GroupScheduleApiControllerTest.java
@@ -4,6 +4,7 @@ import static com.potato_y.where_are_you.group.GroupTestUtils.createGroup;
 import static com.potato_y.where_are_you.group.GroupTestUtils.createGroupHost;
 import static com.potato_y.where_are_you.group.GroupTestUtils.createGroupMember;
 import static com.potato_y.where_are_you.user.UserTestUtils.createUser;
+import static com.potato_y.where_are_you.utils.SecurityContextUtils.setAuthentication;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -38,8 +39,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -49,7 +48,6 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")
 class GroupScheduleApiControllerTest {
 
@@ -93,14 +91,15 @@ class GroupScheduleApiControllerTest {
     groupRepository.deleteAll();
     userRepository.deleteAll();
 
+    userRepository.findAll();  // flush 목적
     testUser = userRepository.save(createUser("test@mail.com", "test user", "1"));
   }
 
   @Test
   @Transactional
-  @WithMockUser("1")
   @DisplayName("createGroupSchedule(): 그룹 스케줄을 추가할 수 있다 - 호스트")
   void successCreateGroupSchedule_host() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule";
 
     Group testGroup = groupRepository.save(createGroup("test group", testUser));
@@ -144,9 +143,9 @@ class GroupScheduleApiControllerTest {
 
   @Test
   @Transactional
-  @WithMockUser("1")
   @DisplayName("createGroupSchedule(): 그룹 스케줄을 추가할 수 있다 - 호스트")
   void successCreateGroupSchedule_member() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule";
 
     User hostUser = userRepository.save(createUser("host@mail.com", "host", "213"));
@@ -192,9 +191,9 @@ class GroupScheduleApiControllerTest {
 
   @Test
   @Transactional
-  @WithMockUser("1")
   @DisplayName("createGroupSchedule(): 그룹 스케줄을 추가할 수 있다 - 알람 없이")
   void successCreateGroupSchedule_notAlarm() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule";
 
     Group testGroup = groupRepository.save(createGroup("test group", testUser));
@@ -237,9 +236,9 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("createGroupSchedule(): 그룹원이 아니라면 권한 예외가 발생한다")
   void failCreateGroupSchedule_notGroupMember() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule";
 
     User hostUser = userRepository.save(createUser("host@mail.com", "host", "213"));
@@ -266,9 +265,9 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("getGroupSchedules(): 그룹의 스케줄 목록을 가져올 수 있다")
   void successGetGroupSchedules() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule";
 
     User hostUser = userRepository.save(createUser("host@mail.com", "host", "213"));
@@ -339,9 +338,9 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("getGroupSchedules(): 그룹원이 아니라면 조회할 수 없다")
   void failGetGroupSchedules_notMember() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule";
 
     User hostUser = userRepository.save(createUser("host@mail.com", "host", "213"));
@@ -355,9 +354,9 @@ class GroupScheduleApiControllerTest {
 
   @Test
   @Transactional
-  @WithMockUser("1")
   @DisplayName("registerParticipation(): 처음으로 스케줄 참여를 신청할 수 있다 - 호스트")
   void successRegisterParticipation_noData_groupHost() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}/participation";
 
     Group testGroup = groupRepository.save(createGroup("test group", testUser));
@@ -382,9 +381,9 @@ class GroupScheduleApiControllerTest {
 
   @Test
   @Transactional
-  @WithMockUser("1")
   @DisplayName("registerParticipation(): 처음으로 스케줄 참여를 신청할 수 있다 - 그룹원")
   void successRegisterParticipation_noData_groupMember() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}/participation";
 
     User hostUser = userRepository.save(createUser("host@mail.com", "host", "213"));
@@ -412,9 +411,9 @@ class GroupScheduleApiControllerTest {
 
   @Test
   @Transactional
-  @WithMockUser("1")
   @DisplayName("registerParticipation(): 취소한 일정을 다시 신청할 수 있다")
   void successRegisterParticipation_updateData() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}/participation";
 
     User hostUser = userRepository.save(createUser("host@mail.com", "host", "213"));
@@ -446,9 +445,9 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("registerParticipation(): 그룹원이 아니라면 참여할 수 없다")
   void failRegisterParticipation_notMember() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}/participation";
 
     User hostUser = userRepository.save(createUser("host@mail.com", "host", "213"));
@@ -467,9 +466,9 @@ class GroupScheduleApiControllerTest {
 
   @Test
   @Transactional
-  @WithMockUser("1")
   @DisplayName("cancelParticipation(): 참여를 취소할 수 있다")
   void successCancelParticipation() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}/participation";
 
     User hostUser = userRepository.save(createUser("host@mail.com", "host", "213"));
@@ -501,9 +500,9 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("cancelParticipation(): 그룹원이 아니라면 참여를 취소할 수 없다")
   void failCancelParticipation_notMember() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}/participation";
 
     User hostUser = userRepository.save(createUser("host@mail.com", "host", "213"));
@@ -521,9 +520,9 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("getParticipationList(): 특정 스케줄의 참여자 목록을 가져올 수 있다")
   void successGetParticipationList() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}/participation";
 
     User hostUser = userRepository.save(createUser("host@mail.com", "host", "213"));
@@ -556,9 +555,9 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("getParticipationList(): 그룹원이 아니라면 스케줄의 참여자 목록을 가져올 수 없다")
   void failGetParticipationList_notMember() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}/participation";
 
     User hostUser = userRepository.save(createUser("host@mail.com", "host", "213"));
@@ -582,9 +581,9 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("deleteGroupSchedule(): 스케줄을 삭제할 수 있다")
   void successDeleteGroupSchedule() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}";
 
     Group testGroup = groupRepository.save(createGroup("test group", testUser));
@@ -614,9 +613,9 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("deleteGroupSchedule(): 그룹 유저가 아니라면 스케줄을 삭제할 수 없다")
   void failDeleteGroupSchedule_notGroupMember() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}";
 
     User hostUser = userRepository.save(createUser("host@mail.com", "host", "213"));
@@ -637,9 +636,9 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("deleteGroupSchedule(): 스케줄을 생성한 유저가 아니라면 스케줄을 삭제할 수 없다")
   void failDeleteGroupSchedule_notScheduleOwner() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}";
 
     User hostUser = userRepository.save(createUser("host@mail.com", "host", "213"));
@@ -661,10 +660,10 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @Transactional
   @DisplayName("modifyGroupSchedule(): 그룹 스케줄을 변경할 수 있다 - 이미 알람이 등록된 경우, 알람 시간 업데이트")
   void successModifyGroupSchedule_updateAlarm() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}";
 
     Group testGroup = groupRepository.save(createGroup("test group", testUser));
@@ -717,10 +716,10 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @Transactional
   @DisplayName("modifyGroupSchedule(): 그룹 스케줄을 변경할 수 있다 - 알람 비활성화")
   void successModifyGroupSchedule_deleteAlarm() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}";
 
     Group testGroup = groupRepository.save(createGroup("test group", testUser));
@@ -769,10 +768,10 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @Transactional
   @DisplayName("modifyGroupSchedule(): 그룹 스케줄을 변경할 수 있다 - 알람 활성화(생성)")
   void successModifyGroupSchedule_createAlarm() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}";
 
     Group testGroup = groupRepository.save(createGroup("test group", testUser));
@@ -821,9 +820,9 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("modifyGroupSchedule(): 그룹 스케줄을 변경할 수 없다 - 없는 스케줄")
   void failModifyGroupSchedule_notSchedule() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}";
 
     Group testGroup = groupRepository.save(createGroup("test group", testUser));
@@ -850,9 +849,9 @@ class GroupScheduleApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("modifyGroupSchedule(): 그룹 스케줄을 변경할 수 없다 - 스케줄 생성자가 아님")
   void failModifyGroupSchedule_notScheduleOwner() throws Exception {
+    setAuthentication(testUser);
     final var url = "/v1/groups/{groupId}/schedule/{scheduleId}";
 
     User hostUser = userRepository.save(createUser("host@mail.com", "host", "213"));
@@ -877,7 +876,7 @@ class GroupScheduleApiControllerTest {
     final var requestBody = objectMapper.writeValueAsString(request);
 
     ResultActions result = mockMvc.perform(
-        put(url, testGroup.getId(), 1L)
+        put(url, testGroup.getId(), schedule.getId())
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(requestBody));
 

--- a/src/test/java/com/potato_y/where_are_you/user/UserApiControllerTest.java
+++ b/src/test/java/com/potato_y/where_are_you/user/UserApiControllerTest.java
@@ -1,6 +1,7 @@
 package com.potato_y.where_are_you.user;
 
 import static com.potato_y.where_are_you.user.UserTestUtils.createUser;
+import static com.potato_y.where_are_you.utils.SecurityContextUtils.setAuthentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -20,8 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -30,7 +29,6 @@ import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @ActiveProfiles("test")
 class UserApiControllerTest {
 
@@ -52,7 +50,6 @@ class UserApiControllerTest {
   }
 
   @DisplayName("getMyAccount(): 자신의 정보를 불러온다")
-  @WithMockUser(username = "1")
   @Test
   public void successGetMyAccount() throws Exception {
     final String url = "/v1/users/me";
@@ -63,6 +60,7 @@ class UserApiControllerTest {
         .nickname("name")
         .providerAccountId("2")
         .build());
+    setAuthentication(user);
 
     ResultActions result = mockMvc.perform(get(url));
 
@@ -73,11 +71,12 @@ class UserApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("updateUserLate(): 지각 카운트를 추가할 수 있다 - 새로운 추가")
   void successUpdateUserLate_new_true() throws Exception {
     final String url = "/v1/users/late";
     User user = userRepository.save(createUser("test@mail.com", "test user", "1"));
+    setAuthentication(user);
+
     UserLateRequest request = new UserLateRequest(true);
     final var requestBody = objectMapper.writeValueAsString(request);
 
@@ -93,11 +92,12 @@ class UserApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("updateUserLate(): 지각 카운트를 추가할 수 있다 - 새로운 추가")
   void successUpdateUserLate_new_false() throws Exception {
     final String url = "/v1/users/late";
     User user = userRepository.save(createUser("test@mail.com", "test user", "1"));
+    setAuthentication(user);
+
     UserLateRequest request = new UserLateRequest(false);
     final var requestBody = objectMapper.writeValueAsString(request);
 
@@ -113,13 +113,14 @@ class UserApiControllerTest {
   }
 
   @Test
-  @WithMockUser("1")
   @DisplayName("updateUserLate(): 지각 카운트를 추가할 수 있다 - 기존 값을 업데이트")
   void successUpdateUserLate_update() throws Exception {
     final String url = "/v1/users/late";
     User user = userRepository.save(createUser("test@mail.com", "test user", "1"));
     userLateRepository.save(
         UserLate.builder().user(user).build().upCount(true));
+    setAuthentication(user);
+
     UserLateRequest request = new UserLateRequest(true);
     final var requestBody = objectMapper.writeValueAsString(request);
 

--- a/src/test/java/com/potato_y/where_are_you/utils/SecurityContextUtils.java
+++ b/src/test/java/com/potato_y/where_are_you/utils/SecurityContextUtils.java
@@ -1,0 +1,15 @@
+package com.potato_y.where_are_you.utils;
+
+import com.potato_y.where_are_you.user.domain.User;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityContextUtils {
+
+  public static void setAuthentication(User user) {
+    SecurityContext context = SecurityContextHolder.getContext();
+    context.setAuthentication(
+        new UsernamePasswordAuthenticationToken(user, user.getPassword(), user.getAuthorities()));
+  }
+}


### PR DESCRIPTION
**이번 Pull request에는 다음의 내용이 포함되어 있습니다.**

### Test

#### 기존

각 테스트 마다 User 데이터를 전체 삭제하여도 PK 값이 자동으로 증가하기 때문에 @DirtiesContext 애너테이션을 통해 Spring Context를 재생성하였습니다.

#### 변경

- `@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)` 애너테이션을 삭제합니다.
- `@WithMockUser` 애너테이션을 삭제합니다.
- SecurityContextUtils: SecurityContext에 사용자의 인증 정보를 직접 추가합니다.

#### 결과

테스트 시간이 개선됩니다.
- 기존: 약 1분
- 이후: 약 5~8초

#### 그 외 변경 사항
- failModifyGroupSchedule_notScheduleOwner 코드의 schedule id 값을 1로 고정된 내용을 schedule 객체를 통해 가져오도록 변경합니다.