### PR TITLE
develop ← feature/improved invitation code structure: Code 형식 변경, 만료 코드 삭제 스케줄 추가

### DIFF
--- a/src/main/java/com/potato_y/where_are_you/common/utils/CodeMaker.java
+++ b/src/main/java/com/potato_y/where_are_you/common/utils/CodeMaker.java
@@ -1,20 +1,10 @@
 package com.potato_y.where_are_you.common.utils;
 
-import java.util.Random;
+import java.util.UUID;
 
 public class CodeMaker {
 
-  private static final String FULL_CHARACTERS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
-  public static String createCode(int length) {
-    Random random = new Random();
-
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < length; i++) {
-      int index = random.nextInt(FULL_CHARACTERS.length());
-      sb.append(FULL_CHARACTERS.charAt(index));
-    }
-
-    return sb.toString();
+  public static String createCode() {
+    return UUID.randomUUID().toString();
   }
 }

--- a/src/main/java/com/potato_y/where_are_you/group/GroupInviteCodeScheduler.java
+++ b/src/main/java/com/potato_y/where_are_you/group/GroupInviteCodeScheduler.java
@@ -1,0 +1,29 @@
+package com.potato_y.where_are_you.group;
+
+import com.potato_y.where_are_you.group.domain.GroupInviteCode;
+import com.potato_y.where_are_you.group.domain.GroupInviteCodeRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class GroupInviteCodeScheduler {
+
+  private final GroupInviteCodeRepository groupInviteCodeRepository;
+  private static final int EXPIRATION_DATE_CRITERIA = 2;
+
+  @Scheduled(fixedDelay = 60000)
+  @Transactional
+  public void deleteUserLocation() {
+    LocalDateTime twoDaysAgo = LocalDateTime.now().minusDays(EXPIRATION_DATE_CRITERIA);
+
+    List<GroupInviteCode> groupInviteCodes = groupInviteCodeRepository
+        .findAllByCreatedAtBefore(twoDaysAgo);
+
+    groupInviteCodeRepository.deleteAll(groupInviteCodes);
+  }
+}

--- a/src/main/java/com/potato_y/where_are_you/group/GroupService.java
+++ b/src/main/java/com/potato_y/where_are_you/group/GroupService.java
@@ -93,12 +93,11 @@ public class GroupService {
     return new GroupInviteCodeResponse(groupId, groupInviteCode.getCode());
   }
 
-  @Transactional(readOnly = true)
-  protected String getUniqueInviteCode() {
-    String code = createCode(GROUP_INVITE_CODE_LENGTH);
+  private String getUniqueInviteCode() {
+    String code = createCode();
 
     while (groupInviteCodeRepository.findByCode(code).isPresent()) {
-      code = createCode(GROUP_INVITE_CODE_LENGTH);
+      code = createCode();
     }
 
     return code;

--- a/src/main/java/com/potato_y/where_are_you/group/domain/GroupInviteCodeRepository.java
+++ b/src/main/java/com/potato_y/where_are_you/group/domain/GroupInviteCodeRepository.java
@@ -1,9 +1,13 @@
 package com.potato_y.where_are_you.group.domain;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupInviteCodeRepository extends JpaRepository<GroupInviteCode, Long> {
 
   Optional<GroupInviteCode> findByCode(String code);
+
+  List<GroupInviteCode> findAllByCreatedAtBefore(LocalDateTime createdAt);
 }

--- a/src/test/java/com/potato_y/where_are_you/group/GroupServiceTest.java
+++ b/src/test/java/com/potato_y/where_are_you/group/GroupServiceTest.java
@@ -241,19 +241,6 @@ class GroupServiceTest {
   }
 
   @Test
-  @DisplayName("getUniqueInviteCode(): 고유한 코드를 생성할 수 있다.")
-  void successGetUniqueInviteCode() {
-    // given
-    given(groupInviteCodeRepository.findByCode(any(String.class))).willReturn(Optional.empty());
-
-    // when
-    String result = groupService.getUniqueInviteCode();
-
-    // then
-    assertThat(result).hasSize(10);
-  }
-
-  @Test
   @DisplayName("updateGroup(): 그룹 정보를 변경할 수 있다.")
   void successUpdateGroup() {
     // given


### PR DESCRIPTION
**이번 Pull request에는 다음의 내용이 포함되어 있습니다.**

### Group

- 초대 코드의 형식이 변경됩니다.
  - 기존: 10자리의 숫자, 알파벳 조합
  - 변경: UUID 버전 4로 변경
  - 초대 코드는 사용자에게 직접적으로 표시되지 않기 때문에 고유성을 더 보장할 수 있는 방향으로 변경합니다. 과거 발급된 코드와 중복되어 과거 링크를 통해 다른 그룹에 가입되는 문제를 방지합니다.
- 만료된 초대 링크 삭제 스케줄 기능 추가